### PR TITLE
Use SITE_SUBTEXT for index Page Title

### DIFF
--- a/alchemy/templates/base.html
+++ b/alchemy/templates/base.html
@@ -7,7 +7,7 @@
             <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
             <meta name="viewport" content="width=device-width, initial-scale=1">
 
-            <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
+            <title>{% block title %}{{ SITE_SUBTEXT }}{% endblock title %}</title>
 
             {% include "include/feeds.html" %}
             <link rel="stylesheet" href="{{ SITEURL }}/theme/css/style.css">


### PR DESCRIPTION
Improve search engine visibility, `SITE_SUBTEXT` acts as a more descriptive title; at least in our case https://github.com/nairobilug/nairobilug.or.ke/blob/e992f65/pelicanconf.py
