### PR TITLE
Fix missing article summary on the index template

### DIFF
--- a/alchemy/templates/index.html
+++ b/alchemy/templates/index.html
@@ -26,7 +26,7 @@ All Articles
     </div>
     <div class="col-sm-8 teaser-main">
       <h2><a href="/{{ article.url }}" title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h2>
-      <p>{{ article.content|striptags|truncate(256) }}</p>
+      <p>{{ article.summary }}</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Show the `{{ article.summary }}` for teasers. Closes #33.