### PR TITLE
Fix path building for empty or "/" SITEURL configurations, add quotes to img src element

### DIFF
--- a/alchemy/templates/base.html
+++ b/alchemy/templates/base.html
@@ -58,13 +58,13 @@
       <div class="row">
         {% if SITEIMAGE %}
         <div class="col-sm-4">
-          <a href="{{ SITEURL }}">
-            <img class="img-fluid" src={{ SITEURL }}{{ SITEIMAGE }} alt="{{ SITENAME }}">
+          <a href="{{ SITEURL }}/">
+            <img class="img-fluid" src="{{ SITEURL }}{{ SITEIMAGE }}" alt="{{ SITENAME }}">
           </a>
         </div>
         {% endif %}
         <div class="col-sm-{% if SITEIMAGE %}8{% else %}12{% endif %}">
-          <h1 class="title"><a href="{{ SITEURL }}">{{ SITENAME }}</a></h1>
+          <h1 class="title"><a href="{{ SITEURL }}/">{{ SITENAME }}</a></h1>
           {% if SITESUBTITLE %}
           <p class="text-muted">{{ SITESUBTITLE }}</p>
           {% endif %}


### PR DESCRIPTION
According to https://github.com/getpelican/pelican/issues/1156#issuecomment-29557672 a theme must correctly set the trailing slash for URLs, especially for the main SITEURL. This change here offers a way to fix this for Pelican setups that run on the domain root and have a) not set SITEURL at all, or b) set it to "/".