### PR TITLE
Add configuration parameter to override the stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Visit the [Settings wiki](https://github.com/nairobilug/pelican-alchemy/wiki/Set
 - **PYGMENTS_STYLE**: Built-in Pygments style for syntax highlighting.
 - **HIDE_AUTHORS**: Hide the author(s) of an article - useful for single author sites.
 - **RFG_FAVICONS**: Use a Favicon Generator package.
+- **THEME_CSS_OVERRIDES**: Sequence of stylesheet URLs to override CSS provided by theme.
+  Both relative and absolute URLs are supported.
 
 Misc settings:
 

--- a/alchemy/templates/base.html
+++ b/alchemy/templates/base.html
@@ -21,6 +21,13 @@
   <link rel="stylesheet" href="{{ SITEURL }}/theme/css/font-awesome.min.css">
   <link rel="stylesheet" href="{{ SITEURL }}/theme/css/pygments/{{ PYGMENTS_STYLE|default('default') }}.min.css">
   <link rel="stylesheet" href="{{ SITEURL }}/theme/css/theme.css">
+  {% for stylesheet in THEME_CSS_OVERRIDES or () %}
+  {% if stylesheet|lower|truncate(4, True, '') == 'http' %}
+  <link rel="stylesheet" href="{{ stylesheet }}">
+  {% else %}
+  <link rel="stylesheet" href="{{ SITEURL + '/' + stylesheet }}">
+  {% endif %}
+  {% endfor %}
 
   {% include 'include/xml_feeds.html' %}
   {% block head %}{% endblock %}


### PR DESCRIPTION
This commit adds new configuration parameter, THEME_CSS_OVERRIDES, which can contain a sequence (list, tuple, etc) of URLs to extra stylesheets that will be used to override default theme appearance. Both absolute and relative URLs are supported.

It makes the theme more flexible by allowing small stylesheet tweaks without requiring to maintain a fork of the whole theme.

When this parameter is not set the theme behaves same as before.