### PR TITLE
Support for comments through isso

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Misc settings:
 - **DISQUS_SITENAME**
 - **GAUGES**
 - **GOOGLE_ANALYTICS**
+- **ISSO_URL**
 - **PIWIK_URL**
 - **PIWIK_SITE_ID**
 

--- a/alchemy/templates/include/comments.html
+++ b/alchemy/templates/include/comments.html
@@ -18,3 +18,10 @@
     Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a>
   </noscript>
 {% endif %}
+{% if ISSO_URL and SITEURL and article.status != "draft" %}
+  <div id="isso_thread">
+  <script data-isso="{{ ISSO_URL }}/"
+    src="{{ ISSO_URL }}/js/embed.min.js"></script>
+  <section id="isso-thread"></section>
+  </div>
+{% endif %}


### PR DESCRIPTION
[isso](https://github.com/posativ/isso) is an open source alternative for discuss that people can selfhost. It works great for weblogs, rather easy to set up, just using a sqlite database.