### PR TITLE
Article image

### DIFF
--- a/alchemy/templates/article.html
+++ b/alchemy/templates/article.html
@@ -42,6 +42,10 @@
           </li>
         {% endif %}
       </ul>
+      {% if article.image %}
+        <img class="article-image img-fluid rounded" alt="article header image" itemprop="image"
+          src="{{ article.image }}" />
+      {% endif %}
     </header>
     <div class="content">
       {{ article.content }}

--- a/alchemy/templates/article.html
+++ b/alchemy/templates/article.html
@@ -42,10 +42,12 @@
           </li>
         {% endif %}
       </ul>
+      {#
       {% if article.image %}
         <img class="article-image img-fluid rounded" alt="article header image" itemprop="image"
           src="{{ article.image }}" />
       {% endif %}
+      #}
     </header>
     <div class="content">
       {{ article.content }}

--- a/alchemy/templates/index.html
+++ b/alchemy/templates/index.html
@@ -45,6 +45,10 @@
         <div class="content">
           {{ article.summary|striptags }}
         </div>
+        {% if article.image %}
+          <img class="article-image img-fluid rounded" alt="article header image" itemprop="image"
+            src="{{ article.image }}" />
+        {% endif %}
       </div>
     </article>
     {% if not loop.last %}


### PR DESCRIPTION
Support showing the image configured in an article in both the header of the article itself as on the index page, below the summary of the article.

[An example can be found on my weblog](https://dammit.nl/moved-to-pelican.html).