### PR TITLE
Merge GitHub wiki contents into main repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ THEME = alchemy.path()
 
 ## Usage
 
-Visit the [Settings wiki](https://github.com/nairobilug/pelican-alchemy/wiki/Settings) for examples:
+Visit the [Settings docs](docs/settings.md) for examples:
 
 - **SITESUBTITLE**: Subtitle that appears in the header.
 - **SITEIMAGE**: Image that appears in the header.
@@ -141,7 +141,7 @@ Example [pelicanconf.py](https://github.com/nairobilug/pelican-alchemy/blob/demo
 
 ### Tips & Tricks
 
-https://github.com/nairobilug/pelican-alchemy/wiki/Tips
+[See documentation page](docs/pelican-tips.md)
 
 ## How to Contribute
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-Welcome to the pelican-alchemy wiki!
+Welcome to the pelican-alchemy documentation!
 
-- [Pelican Tips](wiki/Pelican-Tips)
-- [Settings](wiki/Settings)
+- [Pelican Tips](pelican-tips.md)
+- [Settings](settings.md)

--- a/docs/pelican-tips.md
+++ b/docs/pelican-tips.md
@@ -1,3 +1,5 @@
+# Pelican Tips
+
 ## Bootstrap Classes
 
 To have Bootstrap classes set for rendered html (`.table`, `.img-fluid` etc), use the [Bootstrapify](https://github.com/ingwinlu/pelican-bootstrapify) Pelican plugin.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,3 +1,5 @@
+# Settings
+
 Unless otherwise specified, settings that refer to paths can be either absolute or relative to the configuration file.
 
 ## SITESUBTITLE


### PR DESCRIPTION
GitHub wikis are not really wikis since they may only be edited by project members. They are much less visible to passers-by than the docs in the main repo. For small projects that often means they are the place where documentation goes to die.

I suggest moving all documentation into one place: the `docs/` directory in main repo. That has the following advantages:

- Anyone can suggest documentation enhancement via standard pull request
- Docs are cloned along with the rest of the repo and are available offline
- Docs are more visible to passers-by: the `docs/` folder is right there on the first screen. Having "Wiki" link in the header is not the same - it does not mean the wiki is not empty, user has to click to learn that - and in most GitHub projects wiki *is* empty, so no one bothers clicking.
- Docs are more visible to developers. They are right there in git workdir. `git grep` returns matches from both docs and the code at once. That means the docs will be less often forgotten and left out of sync.

Other people have spoken out in favor of this approach:

- https://www.dzombak.com/blog/2015/03/Why-use-GitHub-Wikis-.html

This pull request merges wiki contents (which was tracked in git repo behind the scenes) into `docs/` - while preserving all edit history and author information.

GitHub Wiki should be disabled after this pull request is merged.