### PR TITLE
Support for link posts through the Link: metadata field

### DIFF
--- a/alchemy/templates/archives.html
+++ b/alchemy/templates/archives.html
@@ -12,7 +12,7 @@
   <dl class="row">
     {% for article in dates %}
       <dt class="col-sm-4">{{ article.locale_date }}</dt>
-      <dd class="col-sm-8"><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></dd>
+      <dd class="col-sm-8"><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}{% if article.link %} <i class="fas fa-link"></i>{% endif %}</a></dd>
     {% endfor %}
   </dl>
 {% endblock %}

--- a/alchemy/templates/article.html
+++ b/alchemy/templates/article.html
@@ -10,7 +10,13 @@
 {% endblock %}
 
 {% block page_header %}
+  {% if article.link %}
+    <a href="{{ article.link }}" rel="bookmark">
+  {% endif %}
   {{ article.title }}
+  {% if article.link %}
+    <i class="fas fa-link"></i></a>
+  {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -53,6 +59,11 @@
     </header>
     <div class="content">
       {{ article.content }}
+      {% if article.link %}
+        <p class="link-button"><a href="{{ article.link }}" rel="bookmark">
+          <i class="fas fa-link"></i> view link
+        </a></p>
+      {% endif %}
     </div>
   </article>
   {% include 'include/comments.html' %}

--- a/alchemy/templates/index.html
+++ b/alchemy/templates/index.html
@@ -40,7 +40,7 @@
       </header>
       <div class="col-sm-8">
         <h4 class="title">
-          <a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a>
+          <a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}{% if article.link %} <i class="fas fa-link"></i>{% endif %}</a>
         </h4>
         <div class="content">
           {{ article.summary|striptags }}

--- a/docs/pelican-tips.md
+++ b/docs/pelican-tips.md
@@ -59,6 +59,11 @@ RFG_FAVICONS = True
 unzip -l <PATH_TO_PACKAGE>.zip
 ```
 
+## Link posts
+
+When adding a Link: field to the post's metadata header, the article will be rendered as a link post, which means a link icon will appear behind its title, and the title of the article will link to the destination of the link when viewing the article page. In that same page a 'view link' link/button will be rendered at the end of the content.
+
+
 ## Use `sitemap.xml`
 
 There is a `sitemap.html` Jinja2 template that can be used to [generate a sitemap](https://github.com/getpelican/pelican/wiki/Tips-n-Tricks#generate-sitemapxml).


### PR DESCRIPTION
In relation to https://github.com/getpelican/pelican/issues/565 I implemented theme support for the 'Link:' field in an article. It will render a Font Awesome link icon behind the article.title, on the article page it will link the title to the source, and a 'view link' link/button will be added at the end of the article content.

This kind of depends on having Font Awesome 5, as it uses the 'fas fa-link' class.

[An example can be viewed here](https://dammit.nl/link-its-2020-and-youre-living-in-the-future.html)