### PR TITLE
added style for RST admonitions

### DIFF
--- a/alchemy/static/css/theme.css
+++ b/alchemy/static/css/theme.css
@@ -90,6 +90,38 @@ hr {
   text-decoration: underline
 }
 
+.admonition {
+  border: thin solid gray;
+  background-color: lightgrey;
+  padding: .25em .5em;
+  margin-bottom: 1rem;
+}
+
+.admonition .admonition-title {
+  font-weight: bold;
+  background-color: rgba(255,255,255,0.66);
+  text-align: center;
+}
+
+.admonition p.last  {
+  margin-bottom: 0;
+}
+
+.admonition.important, .admonition.note, .admonition.warning {
+  border-color: goldenrod;
+  background-color: lightgoldenrodyellow;
+}
+
+.admonition.attention, .admonition.caution, .admonition.danger, .admonition.error {
+  border-color: red;
+  background-color: lightpink;
+}
+
+.admonition.hint, .admonition.tip {
+  border-color: limegreen;
+  background-color: palegreen;
+}
+
 @media (min-width: 576px) {
   .header .title {
     font-size: 3rem;


### PR DESCRIPTION
I proposed this some time ago (#77), and it was not integrated because
* it was mixed with many other things
* it was deemed not relevant ("This should be better implemented via THEME_CSS_OVERRIDE")

I respectfully disagree with the latter point. Admonitions are a standard feature of RST, they should have a minimal rendering. The one proposed in this PR is far from perfect (I am not much of a designer) and could (should?) be improved. But complete lack of support for the .admonition class in the theme's CSS is a bug, IMHO.